### PR TITLE
Add release party Frankfurt

### DIFF
--- a/events/2017-08-go1.9-release-party.md
+++ b/events/2017-08-go1.9-release-party.md
@@ -30,5 +30,6 @@ Please, keep these in chronological order.
 |  Okinawa       |  Japan       |  Asia        |  August 25th 7PM   |  [doorkeeper](https://okinawa-go.doorkeeper.jp/events/63972)            |
 |  Edmonton      |  Canada      |  Americas    |  August 28th 6:30PM |  [meetup](https://www.meetup.com/startupedmonton/events/242022523/)       |
 |  Berlin        |  Germany     |  Europe      |  August 30th 7PM   |  [meetup](https://www.meetup.com/golang-users-berlin/events/242617466/) |
+|  Frankfurt     |  Germany     |  Europe      |  September 07th 6:30PM |  [meetup](https://www.meetup.com/de-DE/gophers-frm/events/242325815/) |
 
 _¹ Continents: Antarctica, Africa, Americas, Asia, Europe, Oceania._


### PR DESCRIPTION
I have added the Go 1.9 release party in Frankfurt am Main which is a bit later as well. I hope it is fine. 
We have realised that they will be a release party a bit too late and then it was only possible to change the topic of our next meetup without having two meetups in one week. 
